### PR TITLE
ps returns max fist 100 results, added pagination

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -25,7 +25,11 @@ async function main() {
     const { key, value } = values[rndIndex(values)];
 
     params.append(query, key);
-    params.append('ps', value);
+    params.append('ps', Math.min(100, value)); // limit results per page to max 100
+
+    const totalPages = Math.ceil(value / params.get('ps'));
+    const randomPage = Math.floor(Math.random() * totalPages) + 1;
+    params.append('p', randomPage);
 
     const { links, webImage } = await fetchArtObject(params);
     const { title, scLabelLine, plaqueDescriptionEnglish } = await fetchArtObjectDetails(links.self, params);


### PR DESCRIPTION
Added pagination and selection of random page in the request following the fetch for the artObject so all possible results for an artObject are returned for that specific facet instead of the default max 100 that get returned.